### PR TITLE
feat: add path and quick_xml modules with feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,10 @@ include = [
 [badges]
 maintenance = { status = "actively-developed" }
 
+[features]
+default = []
+quick_xml = ["quick-xml/serialize", "serde/derive"]
+
 [dependencies]
+quick-xml = { version = "0.38.0", optional = true }
+serde = { version = "1.0.219", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sniplets"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Serey Vilgelm <sergey@vilgelm.com>"]
 description = "A collection of handy utility functions for Rust projects."

--- a/README.md
+++ b/README.md
@@ -17,3 +17,18 @@ If you prefer to use this project as a direct dependency, you can add it to your
 ```shell
 cargo add sniplets
 ```
+
+## Modules
+
+All modules that require any external dependencies are behind feature flags.
+
+### `path`
+Contains utility functions for working with file paths.
+
+### `quick_xml`
+Provides utility functions for working with XML files using the `quick-xml` crate.
+
+* Feature flag: `quick_xml`
+* Dependencies:
+  - `quick-xml`
+  - `serde`

--- a/deny.toml
+++ b/deny.toml
@@ -88,7 +88,7 @@ ignore = [
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-allow = ["MIT", "Apache-2.0"]
+allow = ["MIT", "Apache-2.0", "Unicode-3.0"]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,6 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
+#![allow(dead_code)]
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+pub mod path;
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+#[cfg(feature = "quick-xml")]
+pub mod quick_xml;

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,107 @@
+use std::{io, path};
+
+/// Returns the relative path from `from_dir` to `to_file` if `to_file`.
+fn get_relative_path<P: AsRef<path::Path>>(from_path: P, to_path: P) -> io::Result<path::PathBuf> {
+    let from_path = path::absolute(from_path)?;
+    let to_path = path::absolute(to_path)?;
+    let mut from_dir_components = from_path.components();
+    let mut to_file_components = to_path.components();
+
+    // Check if the `to_file` is in the same directory tree as `from_dir` on windows
+    #[cfg(target_os = "windows")]
+    if !from_dir_components.next().eq(&to_file_components.next()) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "The `to_file` is not in the same directory tree as `from_dir`",
+        ));
+    }
+
+    // Skip the common components
+    let mut from_dir_component = from_dir_components.next();
+    let mut to_file_component = to_file_components.next();
+    while from_dir_component.eq(&to_file_component) {
+        from_dir_component = from_dir_components.next();
+        to_file_component = to_file_components.next();
+    }
+
+    let mut relative_path = path::PathBuf::new();
+    if from_dir_component.is_some() {
+        // Add `..` for each component in `from_dir` that is not in `to_file`
+        // Manually add one `..` because it was skipped in the loop above
+        relative_path.push("..");
+        for _ in from_dir_components {
+            relative_path.push("..");
+        }
+    }
+
+    // Add the remaining components of `to_file`
+    if let Some(component) = to_file_component {
+        relative_path.push(component);
+        for component in to_file_components {
+            relative_path.push(component);
+        }
+    }
+
+    Ok(relative_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_relative_path_different_drive() {
+        let base = path::Path::new("C:\\");
+        let file = path::Path::new("D:\\file.txt");
+        let result = get_relative_path(base, file);
+        assert!(result.is_err());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_relative_path_same_drive() {
+        let base = path::Path::new("C:\\foo\\bar\\sub");
+        let file = path::Path::new("C:\\xyz\\baz\\file.txt");
+        let rel = get_relative_path(base, file).unwrap();
+        assert_eq!(
+            rel,
+            path::PathBuf::from_iter(["..", "..", "..", "xyz", "baz", "file.txt"])
+        );
+    }
+
+    #[test]
+    fn test_relative_path_same_dir() {
+        let base = path::Path::new("/foo/bar");
+        let file = path::Path::new("/foo/bar/file.txt");
+        let rel = get_relative_path(base, file).unwrap();
+        assert_eq!(rel, path::PathBuf::from("file.txt"));
+    }
+
+    #[test]
+    fn test_relative_path_subdir() {
+        let base = path::Path::new("/foo/bar");
+        let file = path::Path::new("/foo/bar/sub/file.txt");
+        let rel = get_relative_path(base, file).unwrap();
+        assert_eq!(rel, path::PathBuf::from_iter(["sub", "file.txt"]));
+    }
+
+    #[test]
+    fn test_relative_path_parent_dir() {
+        let base = path::Path::new("/foo/bar/sub");
+        let file = path::Path::new("/foo/bar/file.txt");
+        let rel = get_relative_path(base, file).unwrap();
+        assert_eq!(rel, path::PathBuf::from_iter(["..", "file.txt"]));
+    }
+
+    #[test]
+    fn test_relative_path() {
+        let base = path::Path::new("/foo/bar/sub");
+        let file = path::Path::new("/xyz/baz/file.txt");
+        let rel = get_relative_path(base, file).unwrap();
+        assert_eq!(
+            rel,
+            path::PathBuf::from_iter(["..", "..", "..", "xyz", "baz", "file.txt"])
+        );
+    }
+}

--- a/src/quick_xml.rs
+++ b/src/quick_xml.rs
@@ -1,0 +1,63 @@
+//! Helper functions for quick xml crate.
+
+use quick_xml::SeError;
+use quick_xml::se::{Serializer, WriteResult};
+use serde::Serialize;
+use std::fmt::Write;
+
+/// Serializes a value to xml format with indentation.
+pub fn to_string_indent<T>(
+    value: &T,
+    indent_char: char,
+    indent_size: usize,
+) -> Result<String, SeError>
+where
+    T: ?Sized + Serialize,
+{
+    let mut buffer = String::new();
+    to_writer_indent(&mut buffer, value, indent_char, indent_size)?;
+    Ok(buffer)
+}
+
+/// Serializes a value to xml format with indentation and writes it to the provided writer.
+pub fn to_writer_indent<W, T>(
+    mut writer: W,
+    value: &T,
+    indent_char: char,
+    indent_size: usize,
+) -> Result<WriteResult, SeError>
+where
+    W: Write,
+    T: ?Sized + Serialize,
+{
+    let mut serializer = Serializer::new(&mut writer);
+    serializer.indent(indent_char, indent_size);
+    value.serialize(serializer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Serialize)]
+    struct TestStruct {
+        foo: String,
+        bar: i32,
+    }
+
+    #[test]
+    fn test_to_string_indent() {
+        let value = TestStruct {
+            foo: "xyz".to_string(),
+            bar: 7,
+        };
+        let xml = to_string_indent(&value, ' ', 4).unwrap();
+        assert_eq!(
+            xml,
+            r#"<TestStruct>
+    <foo>xyz</foo>
+    <bar>7</bar>
+</TestStruct>"#
+        );
+    }
+}


### PR DESCRIPTION
Introduce a new `path` module providing utilities to compute relative
paths between directories and files, including Windows-specific checks
for drive consistency. Add comprehensive tests for various path cases.

Add a `quick_xml` module behind a feature flag to support XML
serialization using the `quick-xml` crate and `serde`. Update Cargo.toml
to include optional dependencies and feature flags for modular usage.

Update README to document new modules and their feature flags, improving
clarity on external dependencies and usage.